### PR TITLE
reinstall nodes when deleting policy

### DIFF
--- a/lib/puppet/provider/razor.rb
+++ b/lib/puppet/provider/razor.rb
@@ -3,10 +3,10 @@ require 'tempfile'
 
 class Puppet::Provider::Razor < Puppet::Provider
 
-  def get(type, name)
+  def get(type, name, action = nil)
     begin
       response = RestClient.get(
-        "http://localhost:8080/api/collections/#{type}/#{name}"
+        "http://localhost:8080/api/collections/#{[type, name, action].compact.join('/')}"
       )
     rescue RestClient::ResourceNotFound
       return false

--- a/lib/puppet/provider/rz_policy/rest.rb
+++ b/lib/puppet/provider/rz_policy/rest.rb
@@ -34,9 +34,16 @@ Puppet::Type.type(:rz_policy).provide(
   end
 
   def destroy
-    args = { 'name' => resource[:name] }
+    nodes = get('policies', resource[:name], 'nodes')
+    raise(Exception, "Failed to find nodes for #{resource[:name]}") unless nodes
 
-    post('delete-policy', args)
+    nodes['items'].each do |item|
+      Puppet.debug("Reinstalling node #{item['name']}")
+      post('reinstall-node', { 'name' => item['name'] })
+    end
+
+    Puppet.debug("Deleting policy #{resource[:name]}")
+    post('delete-policy', { 'name' => resource[:name] })
   end
 
   def enabled


### PR DESCRIPTION
Razor 0.15.0 adds functionality to delete policies. Previously
ASM simply disabled them and reinstalled the nodes associated
with those policies. It appeared that simply deleting the
policies would take the place of those steps but that is not the
case. When you delete a policy but do not reinstall attached
nodes the node is left in a bad state. When the node reboots
razor thinks it has an O/S already installed on it but does not
know what it is. It ends up booting the "noop" task which means
that it just boots into the hard disk as opposed to booting the
microkernel like it should.

This commit calls reinstall-node on all nodes attached to a
policy after deleting the policy to fix this issue.