### PR TITLE
ASM-4072 make razor restclient options more flexible

### DIFF
--- a/lib/puppet_x/puppetlabs/transport/razor.rb
+++ b/lib/puppet_x/puppetlabs/transport/razor.rb
@@ -1,40 +1,32 @@
+require 'openssl'
+require 'restclient'
+
 module PuppetX::Puppetlabs::Transport
   class Razor
     attr_reader :name
 
     def initialize(opts)
       @name = opts[:name]
-      options  = opts[:options] || {}
-      @options = options.inject({}){|h, (k, v)| h[k.to_sym] = v; h}
-      @options[:host]     = opts[:server]
-      @options[:user]     = opts[:username]
-      @options[:password] = opts[:password]
-      @options[:scheme] ||= 'http'
-      @options[:port] ||= '80'
+
+      @options = opts[:options].inject({}){|h, (k, v)| h[k.to_sym] = v; h} || {}
+      @options[:user]     = opts[:username] if opts[:username]
+      @options[:password] = opts[:password] if opts[:password]
+
+      [[:ssl_client_cert, OpenSSL::X509::Certificate],
+       [:ssl_client_key, OpenSSL::PKey::RSA]].each do |key, init_class|
+        if @options[key].is_a?(String) && File.exists?(@options[key])
+          @options[key] = init_class.new(File.read(@options[key]))
+        end
+      end
+
+      unless (@url = @options.delete(:url))
+        # Build default razor api url from transport parameters
+        @url = "http://#{opts[:server] || 'localhost'}:8080/api"
+      end
     end
 
     def connect
-      if @options[:url]
-        uri = URI.parse(@options[:url])
-        @options[:username] = uri.user
-        @options[:password] = uri.password
-        @options[:host] = uri.host
-        @options[:scheme] = uri.scheme
-        @options[:port] = uri.port
-        @options[:path] = uri.path
-      end
-      if @options[:client_cert]
-        @options[:cert] = OpenSSL::X509::Certificate.new(File.read(@options[:client_cert]))
-        @options[:key] = OpenSSL::PKey::RSA.new(File.read(@options[:client_cert]))
-        @options[:scheme] = 'https'
-      end
-      url = "#{@options[:scheme]}://#{@options[:host]}:#{@options[:port]}/#{@options[:path]}"
-      RestClient::Resource.new(url,
-                               :ssl_client_cert => @options[:cert],
-                               :ssl_client_key => @options[:key],
-                               :user => @options[:user],
-                               :password => @options[:password],
-                               :verify_ssl => OpenSSL::SSL::VERIFY_NONE)
+      RestClient::Resource.new(@url, @options)
     end
 
     def config


### PR DESCRIPTION
Allow specifying any RestClient option through transport options. This
allows e.g. validating the server ssl cert file by passing the
ssl_ca_file option and leaving verify_ssl at its default value of
OpenSSL::SSL::VERIFY_PEER.