### PR TITLE
VXFM-2416 Retry for intermittent razor 502 error

### DIFF
--- a/lib/puppet/provider/razor.rb
+++ b/lib/puppet/provider/razor.rb
@@ -22,7 +22,14 @@ class Puppet::Provider::Razor < Puppet::Provider
       response = @conn["collections/#{[type, name, action].compact.join('/')}"].get
     rescue RestClient::ResourceNotFound
       return false
+    rescue RestClient::Exception => e
+      sleep(10)
+      count += 1
+      Puppet.warning "Retrying failed REST call: %s for error: #{e.response}" % url.to_s
+      retry unless count > 1
+      fail("Rest call failed: #{e.response}")
     end
+
     if response.code == 200
       PSON.parse(response)
     else


### PR DESCRIPTION
Included retry during REST `GET` operation as we are doing for `POST` operations